### PR TITLE
Updating to 7.8, v0.0.6, removing variables that does not exist in te…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Role Variables
 |-----------------------------|--------------------|----------|----------------|
 |`OCP_PROJECT`                | `rhpam`            | Required | OpenShift project name in which to provision this role |
 |`IMAGE_STREAM_NAMESPACE`     | `openshift`        | Optional | Namespaces in which the RHPAM ImageStreams have been installed. |
-|`RHPAM_VERSION_TAG`          | `7.5.0.GA`         | Optional | RHPAM container image tag in registry.redhat.io. I.e. the RHPAM version to deploy. |
+|`RHPAM_VERSION_TAG`          | `7.8.0.GA`         | Optional | RHPAM container image tag in registry.redhat.io. I.e. the RHPAM version to deploy. |
 |`RHPAM_ENVIRONMENT`          | `trial-ephemeral`            | Optional | RHPAM Environment type. Currently "trial-ephemeral" (default) and "authoring" have been tested. |
-|`RHPAM_VERSION_ID`           | `75`      | Optional | The version id used when selecting the RHPAM-Authoring template to test. E.g. `75` for templates of version `7.3.x`, `74` for templates of version `7.4.x`, etc. |
+|`RHPAM_VERSION_ID`           | `78`      | Optional | The version id used when selecting the RHPAM-Authoring template to test. E.g. `78` for templates of version `7.3.x`, `74` for templates of version `7.4.x`, etc. |
 
 OpenShift Version Compatibility
 ------------
@@ -23,7 +23,7 @@ When listing this role in `requirements.yml`, make sure to pin the version of th
 
 ```
 - src: duncandoyle.ansible_openshift_rhpam
-  version: 0.0.5
+  version: 0.0.6
 ```  
 
 The following tables shows the version combinations that are tested and verified:
@@ -35,6 +35,8 @@ The following tables shows the version combinations that are tested and verified
 | 0.0.3   | 3.11.x  |
 | 0.0.4   | 3.11.x  |
 | 0.0.5   | 3.11.x, 4.x |
+| 0.0.6   | 4.5 |
+
 
 Note that if a version combination is not listed above, it does **NOT** mean that it won't work on that
 version. The above table is merely the combinations that we have verified and tested.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 #OCP_PROJECT: labs-infra
 OCP_PROJECT: rhpam
 IMAGE_STREAM_NAMESPACE: openshift
-RHPAM_VERSION_TAG: 7.5.0.GA
-RHPAM_VERSION_ID: 75
+RHPAM_VERSION_TAG: 7.8.0.GA
+RHPAM_VERSION_ID: 78
 RHPAM_ENVIRONMENT: trial-ephemeral
 PAM_SECRETS_TEMPLATE_YML: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{ RHPAM_VERSION_TAG }}/example-app-secret-template.yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,11 +81,11 @@
 
 - name: Set base param fact
   set_fact:
-    TEMPLATE_PARAMS: -p APPLICATION_NAME="rhpam7" -p KIE_ADMIN_USER="pamAdmin" -p KIE_SERVER_CONTROLLER_USER="controllerUser" -p KIE_SERVER_USER="executionUser" -p BUSINESS_CENTRAL_MAVEN_USERNAME="mavenUser" -p BUSINESS_CENTRAL_MEMORY_LIMIT="2Gi"
+    TEMPLATE_PARAMS: -p APPLICATION_NAME="rhpam7" -p KIE_ADMIN_USER="pamAdmin"  -p KIE_SERVER_USER="executionUser" -p BUSINESS_CENTRAL_MAVEN_USERNAME="mavenUser" -p BUSINESS_CENTRAL_MEMORY_LIMIT="4Gi"
 
 - name: Set additional facts for non-trial environment
   set_fact:
-    TEMPLATE_PARAMS: "{{ TEMPLATE_PARAMS }} -p KIE_ADMIN_PWD='redhatpam1' -p KIE_SERVER_CONTROLLER_PWD='test1234!' -p KIE_SERVER_PWD='test1234!' -p BUSINESS_CENTRAL_MAVEN_PASSWORD='test1234!' -p BUSINESS_CENTRAL_HTTPS_SECRET='businesscentral-app-secret' -p KIE_SERVER_HTTPS_SECRET='kieserver-app-secret'"
+    TEMPLATE_PARAMS: "{{ TEMPLATE_PARAMS }} -p KIE_ADMIN_PWD='redhatpam1' -p KIE_SERVER_PWD='test1234!' -p BUSINESS_CENTRAL_MAVEN_PASSWORD='test1234!' -p BUSINESS_CENTRAL_HTTPS_SECRET='businesscentral-app-secret' -p KIE_SERVER_HTTPS_SECRET='kieserver-app-secret'"
   when: RHPAM_ENVIRONMENT != "trial-ephemeral"
 
 - name: Create PAM7 environment
@@ -96,7 +96,7 @@
   when: rhpam_result is failed
 
 - name: Disable OpenShiftStartupStrategy
-  shell: "oc set env dc/rhpam7-rhpamcentr KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED=false KIE_SERVER_CONTROLLER_PWD=test1234! -n {{ OCP_PROJECT }}"
+  shell: "oc set env dc/rhpam7-rhpamcentr KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED=false -n {{ OCP_PROJECT }}"
 
 - name: Configure KIE-Server
-  shell: "oc set env dc/rhpam7-kieserver KIE_SERVER_STARTUP_STRATEGY=ControllerBasedStartupStrategy KIE_SERVER_CONTROLLER_USER=controllerUser KIE_SERVER_CONTROLLER_PWD=test1234! KIE_SERVER_CONTROLLER_SERVICE=rhpam7-rhpamcentr KIE_SERVER_CONTROLLER_PROTOCOL=ws KIE_SERVER_ROUTE_NAME=insecure-rhpam7-kieserver -n {{ OCP_PROJECT }}"
+  shell: "oc set env dc/rhpam7-kieserver KIE_SERVER_STARTUP_STRATEGY=ControllerBasedStartupStrategy  KIE_SERVER_CONTROLLER_SERVICE=rhpam7-rhpamcentr KIE_SERVER_CONTROLLER_PROTOCOL=ws KIE_SERVER_ROUTE_NAME=insecure-rhpam7-kieserver -n {{ OCP_PROJECT }}"


### PR DESCRIPTION
The variables below were removed from the template, therefore, they can't be used in the provisioning. 

    - name: "KIE_SERVER_CONTROLLER_PWD"
    - name: "KIE_SERVER_CONTROLLER_USER"

https://github.com/jboss-container-images/rhpam-7-openshift-image/commit/7fe0b712ef44f206791f20ea3ddf1c884767f26e
https://issues.redhat.com/browse/RHPAM-2175